### PR TITLE
electron renderer example

### DIFF
--- a/examples/electron-renderer-example/index.html
+++ b/examples/electron-renderer-example/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Hello World!</title>
+	
+	<script>
+	window.addEventListener('DOMContentLoaded', () => {
+		for (const type of ['chrome', 'node', 'electron']) {
+			document.getElementById(`${type}-version`).innerText = process.versions[type];
+		}
+		
+		const ioHook = require('../../index');
+		ioHook.start(true);
+		ioHook.on('mouseclick', eventHandler);
+		ioHook.on('keypress', eventHandler);
+		ioHook.on('mousewheel', eventHandler);
+		ioHook.on('mousemove', eventHandler);
+	})
+
+	function eventHandler(event) {
+		console.log(event);
+		document.getElementById("ioHookEvent").innerText = JSON.stringify(event);
+	}
+	</script>
+	
+  </head>
+  
+  <body>
+    We are using Node.js <span id="node-version"></span>,
+    Chromium <span id="chrome-version"></span>,
+    and Electron <span id="electron-version"></span>.
+	<br><br>
+	Try to move your mouse or press any key!
+	<p id="ioHookEvent"></p>
+  </body>
+</html>

--- a/examples/electron-renderer-example/main.js
+++ b/examples/electron-renderer-example/main.js
@@ -1,0 +1,36 @@
+// Modules to control application life and create native browser window
+const {app, BrowserWindow, Menu} = require('electron')
+app.allowRendererProcessReuse = false;
+const path = require('path');
+
+function createWindow () {
+  //remove application menu on Windows
+  //if (process.platform == "win32") Menu.setApplicationMenu(null);
+  
+  // Create the browser window.
+  const mainWindow = new BrowserWindow({
+    width: 1000,
+    height: 600,
+    webPreferences: {
+	  nodeIntegration: true
+    }
+  })
+
+  // and load the index.html of the app.
+  mainWindow.loadFile('index.html')
+
+  // Open the DevTools.
+  mainWindow.webContents.openDevTools()
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.whenReady().then(() => {
+  createWindow()  
+})
+
+// Quit when all windows are closed
+app.on('window-all-closed', function () {
+  app.quit()
+})

--- a/examples/electron-renderer-example/package.json
+++ b/examples/electron-renderer-example/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "electron-quick-start",
+  "version": "1.0.0",
+  "description": "A minimal Electron application",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^9.0.0"
+  }
+}


### PR DESCRIPTION
Additional Electron example is useful for testing in Electron 9+ and demonstrates using iohook in the renderer process. Adapted from https://github.com/electron/electron-quick-start
